### PR TITLE
Send response from webhook endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,7 @@ app.post('/', function(req, res) {
         });
       });
     }
+    res.sendStatus(200);
 });
 
 pool.on('error', function(err, client) {


### PR DESCRIPTION
The webhook endpoint should respond 200 OK to make sure sending clients doesn't need to wait and time out.

This greatly improves the performance when used with PokemonGo-Map since the searcher threads are waiting for the webhook response before continuing the search. 

(It currently blocks 1 second for each wh post)
