### PR TITLE
Fix minor typos in pokelyze_sql.sql

### DIFF
--- a/pokelyze_sql.sql
+++ b/pokelyze_sql.sql
@@ -74,7 +74,8 @@ CREATE TABLE public.pokemon_info
   weight double precision,
   height double precision,
   CONSTRAINT pokemon_info_pkey PRIMARY KEY (pokemon_id)
-)
+);
+
 ALTER TABLE public.pokemon_info
 	OWNER TO pokemon_go_role;
 CREATE INDEX pokemon_info_pokemon_id_idx

--- a/pokelyze_sql.sql
+++ b/pokelyze_sql.sql
@@ -52,10 +52,6 @@ CREATE INDEX longitude_jit_index
   USING btree
   (longitude_jittered);
 
-CREATE INDEX name_index
-  ON public.spotted_pokemon
-  USING btree (name);
-
 CREATE INDEX point_index
   ON public.spotted_pokemon
   USING gist
@@ -85,6 +81,11 @@ CREATE INDEX pokemon_info_pokemon_id_idx
   ON public.pokemon_info
   USING btree
   (pokemon_id);
+
+CREATE INDEX pokemon_info_pokemon_name_index
+  ON public.pokemon_info
+  USING btree
+  (name);
 
 -------- The meta table for recording schema versions
 

--- a/pokelyze_sql.sql
+++ b/pokelyze_sql.sql
@@ -20,7 +20,7 @@ CREATE TABLE public.spotted_pokemon(
 	pokemon_go_era integer,
 	meta_db_version text DEFAULT 'not versioned'::text,
 	meta_row_insertion_time timestamp without time zone,
-	CONSTRAINT encounter_id_unique UNIQUE (encounter_id)
+	CONSTRAINT encounter_id_unique UNIQUE (encounter_id),
 	CONSTRAINT id_primary_key PRIMARY KEY (id)
 
 );

--- a/pokelyze_sql.sql
+++ b/pokelyze_sql.sql
@@ -210,8 +210,6 @@ EXECUTE PROCEDURE get_db_version();
 
 -- Log the time each record was recorded
 
-ALTER TABLE spotted_pokemon ADD COLUMN meta_row_insertion_time timestamp;
-
 CREATE OR REPLACE FUNCTION get_row_insertion_time()
 RETURNS trigger
 LANGUAGE plpgsql


### PR DESCRIPTION
Hello - I was following your guide but opted to create the database from the SQL file rather than the back up. Found some minor syntax errors while I was running it. One thing I wasn't sure of was I received this error:

``` sql
pokemon_go=# ALTER TABLE public.public
pokemon_go-# OWNER TO pokemon_go_role;
ERROR:  relation "public.public" does not exist
```

Not sure what the intention was with the block of code so I haven't made any fixes. Thanks for the great repo btw!
